### PR TITLE
Switch to Rubinius shortcuts in Fancy compiler

### DIFF
--- a/boot/rbx-compiler/compiler/ast/array_literal.rb
+++ b/boot/rbx-compiler/compiler/ast/array_literal.rb
@@ -1,7 +1,7 @@
 class Fancy
   class AST
 
-    class ArrayLiteral < Rubinius::ToolSet::Runtime::AST::ArrayLiteral
+    class ArrayLiteral < Rubinius::ToolSet.current::TS::AST::ArrayLiteral
       attr_accessor :array
       def initialize(line, *array)
         super(line, array)

--- a/boot/rbx-compiler/compiler/ast/assign.rb
+++ b/boot/rbx-compiler/compiler/ast/assign.rb
@@ -10,15 +10,15 @@ class Fancy
 
       def bytecode(g)
         if @ident.constant?
-          Rubinius::ToolSet::Runtime::AST::ConstantAssignment.new(line, @ident.name, @value).bytecode(g)
+          Rubinius::ToolSet.current::TS::AST::ConstantAssignment.new(line, @ident.name, @value).bytecode(g)
         elsif @ident.instance_variable?
-          Rubinius::ToolSet::Runtime::AST::InstanceVariableAssignment.new(line, @ident.name, @value).
+          Rubinius::ToolSet.current::TS::AST::InstanceVariableAssignment.new(line, @ident.name, @value).
             bytecode(g)
         elsif @ident.class_variable?
-          Rubinius::ToolSet::Runtime::AST::ClassVariableAssignment.new(line, @ident.name, @value).
+          Rubinius::ToolSet.current::TS::AST::ClassVariableAssignment.new(line, @ident.name, @value).
             bytecode(g)
         else
-          Rubinius::ToolSet::Runtime::AST::LocalVariableAssignment.new(line, @ident.name, @value).
+          Rubinius::ToolSet.current::TS::AST::LocalVariableAssignment.new(line, @ident.name, @value).
             bytecode(g)
         end
       end

--- a/boot/rbx-compiler/compiler/ast/block.rb
+++ b/boot/rbx-compiler/compiler/ast/block.rb
@@ -1,13 +1,13 @@
 class Fancy
   class AST
 
-    class BlockLiteral < Rubinius::ToolSet::Runtime::AST::Iter
+    class BlockLiteral < Rubinius::ToolSet.current::TS::AST::Iter
       def initialize(line, args, body, partial = false)
         @args = args
-        body = body || Rubinius::ToolSet::Runtime::AST::NilLiteral.new(line)
+        body = body || Rubinius::ToolSet.current::TS::AST::NilLiteral.new(line)
 
         if body.empty?
-          body.unshift_expression Rubinius::ToolSet::Runtime::AST::NilLiteral.new(line)
+          body.unshift_expression Rubinius::ToolSet.current::TS::AST::NilLiteral.new(line)
         end
 
         super(line, args, body)

--- a/boot/rbx-compiler/compiler/ast/class_def.rb
+++ b/boot/rbx-compiler/compiler/ast/class_def.rb
@@ -1,7 +1,7 @@
 class Fancy
   class AST
 
-    class ClassDef < Rubinius::ToolSet::Runtime::AST::Class
+    class ClassDef < Rubinius::ToolSet.current::TS::AST::Class
       def initialize(line, name, parent, body)
         body = AST::ExpressionList.new(line) unless body
 
@@ -12,7 +12,7 @@ class Fancy
         super(line, name, parent, body)
 
         if body.empty?
-          body.unshift_expression Rubinius::ToolSet::Runtime::AST::NilLiteral.new(line)
+          body.unshift_expression Rubinius::ToolSet.current::TS::AST::NilLiteral.new(line)
         end
       end
 
@@ -23,7 +23,7 @@ class Fancy
                                    Identifier.new(line, "Fancy::Documentation"),
                                    Identifier.new(line, "for:append:"),
                                    MessageArgs.new(line,
-                                                   Rubinius::ToolSet::Runtime::AST::Self.new(line),
+                                                   Rubinius::ToolSet.current::TS::AST::Self.new(line),
                                                    docstring))
           # Replace first string expression to set documentation.
           body.body.expressions.unshift setdoc

--- a/boot/rbx-compiler/compiler/ast/expression_list.rb
+++ b/boot/rbx-compiler/compiler/ast/expression_list.rb
@@ -45,7 +45,7 @@ class Fancy
       # and the first one is an string literal, it'll be used as doc.
       # This method removes the first documentation string.
       def shift_docstring
-        if expressions.first.kind_of?(Rubinius::ToolSet::Runtime::AST::StringLiteral) &&
+        if expressions.first.kind_of?(Rubinius::ToolSet.current::TS::AST::StringLiteral) &&
             expressions.size > 1
           expressions.shift
         end

--- a/boot/rbx-compiler/compiler/ast/hash_literal.rb
+++ b/boot/rbx-compiler/compiler/ast/hash_literal.rb
@@ -1,7 +1,7 @@
 class Fancy
   class AST
 
-    class HashLiteral < Rubinius::ToolSet::Runtime::AST::HashLiteral
+    class HashLiteral < Rubinius::ToolSet.current::TS::AST::HashLiteral
       def initialize(line, *array)
         super(line, array)
       end

--- a/boot/rbx-compiler/compiler/ast/identifier.rb
+++ b/boot/rbx-compiler/compiler/ast/identifier.rb
@@ -92,24 +92,24 @@ class Fancy
 
       def bytecode(g)
         if "__FILE__" == @identifier
-          Rubinius::ToolSet::Runtime::AST::StringLiteral.new(line, Fancy::AST::Script.current.filename).
+          Rubinius::ToolSet.current::TS::AST::StringLiteral.new(line, Fancy::AST::Script.current.filename).
             bytecode(g)
         elsif "__LINE__" == @identifier
-          Rubinius::ToolSet::Runtime::AST::FixnumLiteral.new(line, line).bytecode(g)
+          Rubinius::ToolSet.current::TS::AST::FixnumLiteral.new(line, line).bytecode(g)
         elsif nested_classname?
           classnames = @identifier.split("::")
           parent = Identifier.new(@line, classnames.shift)
           classnames.each do |cn|
-            Rubinius::ToolSet::Runtime::AST::ScopedConstant.new(@line, parent, cn.to_sym).bytecode(g)
+            Rubinius::ToolSet.current::TS::AST::ScopedConstant.new(@line, parent, cn.to_sym).bytecode(g)
             child = Identifier.new(@line, cn)
             parent = child
           end
         elsif constant?
-          Rubinius::ToolSet::Runtime::AST::ConstantAccess.new(line, name).bytecode(g)
+          Rubinius::ToolSet.current::TS::AST::ConstantAccess.new(line, name).bytecode(g)
         elsif class_variable?
-          Rubinius::ToolSet::Runtime::AST::ClassVariableAccess.new(line, name).bytecode(g)
+          Rubinius::ToolSet.current::TS::AST::ClassVariableAccess.new(line, name).bytecode(g)
         elsif instance_variable?
-          Rubinius::ToolSet::Runtime::AST::InstanceVariableAccess.new(line, name).bytecode(g)
+          Rubinius::ToolSet.current::TS::AST::InstanceVariableAccess.new(line, name).bytecode(g)
         elsif true?
           g.push_true
         elsif false?
@@ -118,7 +118,7 @@ class Fancy
           g.push_nil
         else
           if g.state.scope.search_local(name)
-            Rubinius::ToolSet::Runtime::AST::LocalVariableAccess.new(@line, name).bytecode(g)
+            Rubinius::ToolSet.current::TS::AST::LocalVariableAccess.new(@line, name).bytecode(g)
           else
             MessageSend.new(line, Self.new(line), self, MessageArgs.new(line)).bytecode(g)
           end

--- a/boot/rbx-compiler/compiler/ast/message_send.rb
+++ b/boot/rbx-compiler/compiler/ast/message_send.rb
@@ -17,7 +17,7 @@ class Fancy
           @receiver.bytecode(g)
           @message_args.bytecode(g)
           pos(g)
-          g.allow_private if @receiver.is_a?(Rubinius::ToolSet::Runtime::AST::Self)
+          g.allow_private if @receiver.is_a?(Rubinius::ToolSet.current::TS::AST::Self)
 
           name = @message_name.method_name(@receiver, ruby_send?)
           if ruby_send_block?

--- a/boot/rbx-compiler/compiler/ast/method_def.rb
+++ b/boot/rbx-compiler/compiler/ast/method_def.rb
@@ -1,7 +1,7 @@
 class Fancy
   class AST
 
-    class MethodDef < Rubinius::ToolSet::Runtime::AST::Define
+    class MethodDef < Rubinius::ToolSet.current::TS::AST::Define
       def initialize(line, method_ident, args, body, access = :public)
         body = AST::ExpressionList.new(line) unless body
 
@@ -13,7 +13,7 @@ class Fancy
         generate_ivar_assignment
 
         if body.empty?
-          body.unshift_expression Rubinius::ToolSet::Runtime::AST::NilLiteral.new(line)
+          body.unshift_expression Rubinius::ToolSet.current::TS::AST::NilLiteral.new(line)
         end
       end
 
@@ -21,7 +21,7 @@ class Fancy
         @arguments.required.reverse.each do |name|
           if name.to_s =~ /^@/
             ident = Fancy::AST::Identifier.new(line, name.to_s)
-            value = Rubinius::ToolSet::Runtime::AST::LocalVariableAccess.new(line, name)
+            value = Rubinius::ToolSet.current::TS::AST::LocalVariableAccess.new(line, name)
             asign = Fancy::AST::Assignment.new(line, ident, value)
             body.unshift_expression(asign)
           end
@@ -69,9 +69,9 @@ class Fancy
       # defines a class method names "new:foo:" if we're defining a
       # method named e.g. "initialize:foo:" (a constructor method).
       def define_constructor_class_method(g)
-        method_ident = Rubinius::ToolSet::Runtime::AST::StringLiteral.new(@line, @name.to_s[11..-1])
+        method_ident = Rubinius::ToolSet.current::TS::AST::StringLiteral.new(@line, @name.to_s[11..-1])
         ms = MessageSend.new(@line,
-                             Rubinius::ToolSet::Runtime::AST::Self.new(@line),
+                             Rubinius::ToolSet.current::TS::AST::Self.new(@line),
                              Identifier.new(@line, "define_constructor_class_method:"),
                              MessageArgs.new(@line, method_ident))
         ms.bytecode(g)
@@ -80,14 +80,14 @@ class Fancy
 
       def define_method_missing(g)
         MessageSend.new(@line,
-                        Rubinius::ToolSet::Runtime::AST::Self.new(@line),
+                        Rubinius::ToolSet.current::TS::AST::Self.new(@line),
                         Identifier.new(@line, "define_forward_method_missing"),
                         MessageArgs.new(@line)).bytecode(g)
         g.pop
       end
     end
 
-    SymbolLiteral = Rubinius::ToolSet::Runtime::AST::SymbolLiteral
+    SymbolLiteral = Rubinius::ToolSet.current::TS::AST::SymbolLiteral
 
     class Nothing
       def bytecode(g)
@@ -106,7 +106,7 @@ class Fancy
       end
     end
 
-    class MethodArgs < Rubinius::ToolSet::Runtime::AST::FormalArguments
+    class MethodArgs < Rubinius::ToolSet.current::TS::AST::FormalArguments
       def initialize(line, *args)
         super(line, args.map(&:to_sym), nil, nil)
       end

--- a/boot/rbx-compiler/compiler/ast/node.rb
+++ b/boot/rbx-compiler/compiler/ast/node.rb
@@ -1,11 +1,11 @@
 class Fancy
   class AST
     [ :Node, :Self, :FixnumLiteral, :NumberLiteral, :RegexLiteral, :ScopedConstant ].
-      each { |n| const_set(n, Rubinius::ToolSet::Runtime::AST.const_get(n)) }
+      each { |n| const_set(n, Rubinius::ToolSet.current::TS::AST.const_get(n)) }
   end
 end
 
-class Rubinius::ToolSet::Runtime::AST::Self
+class Rubinius::ToolSet.current::TS::AST::Self
   def method_name(receiver = nil, with_ruby_args = false)
     if with_ruby_args
       "self".to_sym

--- a/boot/rbx-compiler/compiler/ast/script.rb
+++ b/boot/rbx-compiler/compiler/ast/script.rb
@@ -29,7 +29,7 @@ class Fancy
           push_script
 
           #docs, code = body.expressions.partition do |s|
-          #  s.kind_of?(Rubinius::ToolSet::Runtime::AST::StringLiteral)
+          #  s.kind_of?(Rubinius::ToolSet.current::TS::AST::StringLiteral)
           #end
 
           #if code.empty?

--- a/boot/rbx-compiler/compiler/ast/singleton_method_def.rb
+++ b/boot/rbx-compiler/compiler/ast/singleton_method_def.rb
@@ -1,7 +1,7 @@
 class Fancy
   class AST
 
-    class SingletonMethodDef < Rubinius::ToolSet::Runtime::AST::DefineSingleton
+    class SingletonMethodDef < Rubinius::ToolSet.current::TS::AST::DefineSingleton
       def initialize(line, obj_ident, method_ident, args, body, access = :public)
         body = AST::ExpressionList.new(line) unless body
 
@@ -14,7 +14,7 @@ class Fancy
       end
     end
 
-    class SingletonMethodDefScope < Rubinius::ToolSet::Runtime::AST::DefineSingletonScope
+    class SingletonMethodDefScope < Rubinius::ToolSet.current::TS::AST::DefineSingletonScope
       def initialize(line, name, args, body)
         @line = line
         @name = name

--- a/boot/rbx-compiler/compiler/ast/string_literal.rb
+++ b/boot/rbx-compiler/compiler/ast/string_literal.rb
@@ -1,6 +1,6 @@
 class Fancy
   class AST
-    class StringLiteral < Rubinius::ToolSet::Runtime::AST::StringLiteral
+    class StringLiteral < Rubinius::ToolSet.current::TS::AST::StringLiteral
       def initialize(line, str)
         super(line, unescape_chars(str))
       end

--- a/boot/rbx-compiler/compiler/ast/try_catch_block.rb
+++ b/boot/rbx-compiler/compiler/ast/try_catch_block.rb
@@ -6,7 +6,7 @@ class Fancy
         super(line)
         @body = body
         @handlers = handlers
-        @finally = finally || Rubinius::ToolSet::Runtime::AST::NilLiteral.new(line)
+        @finally = finally || Rubinius::ToolSet.current::TS::AST::NilLiteral.new(line)
       end
 
       def bytecode(g)
@@ -31,7 +31,7 @@ class Fancy
         finally = g.new_label
         done = g.new_label
 
-        g.setup_unwind handler, Rubinius::ToolSet::Runtime::AST::RescueType
+        g.setup_unwind handler, Rubinius::ToolSet.current::TS::AST::RescueType
 
         # make a break available to use
         if current_break = g.break

--- a/boot/rbx-compiler/compiler/ast/tuple_literal.rb
+++ b/boot/rbx-compiler/compiler/ast/tuple_literal.rb
@@ -14,7 +14,7 @@ class Fancy
                              Identifier.new(@line, "new"),
                              MessageArgs.new(@line,
                                              RubyArgs.new(@line,
-                                                          ArrayLiteral.new(@line, Rubinius::ToolSet::Runtime::AST::FixnumLiteral.new(@line, @elements.size)))))
+                                                          ArrayLiteral.new(@line, Rubinius::ToolSet.current::TS::AST::FixnumLiteral.new(@line, @elements.size)))))
         ms.bytecode(g)
         @elements.each_with_index do |e, i|
           g.dup
@@ -22,7 +22,7 @@ class Fancy
                           Nothing.new,
                           Identifier.new(@line, "at:put:"),
                           MessageArgs.new(@line,
-                                          Rubinius::ToolSet::Runtime::AST::FixnumLiteral.new(@line, i),
+                                          Rubinius::ToolSet.current::TS::AST::FixnumLiteral.new(@line, i),
                                           e)).bytecode(g)
           g.pop
         end

--- a/boot/rbx-compiler/compiler/compiler.rb
+++ b/boot/rbx-compiler/compiler/compiler.rb
@@ -4,7 +4,7 @@ require "rubinius/compiler"
 
 class Fancy
 
-  class Compiler < Rubinius::ToolSet::Runtime::Compiler
+  class Compiler < Rubinius::ToolSet.current::TS::Compiler
 
     def self.fancy_compiled_name(file)
       if file.suffix? ".fy"
@@ -19,7 +19,7 @@ class Fancy
       compiler = new :fancy_file, :compiled_file
 
       parser = compiler.parser
-      parser.root Rubinius::ToolSet::Runtime::AST::Script
+      parser.root Rubinius::ToolSet.current::TS::AST::Script
 
       parser.input file, line
 
@@ -44,7 +44,7 @@ class Fancy
       compiler = new :fancy_code, :compiled_method
 
       parser = compiler.parser
-      parser.root Rubinius::ToolSet::Runtime::AST::Script
+      parser.root Rubinius::ToolSet.current::TS::AST::Script
       parser.input code, filename, line
 
       if print
@@ -65,7 +65,7 @@ class Fancy
       compiler = new :fancy_code, :compiled_method
 
       parser = compiler.parser
-      parser.root Rubinius::ToolSet::Runtime::AST::EvalExpression
+      parser.root Rubinius::ToolSet.current::TS::AST::EvalExpression
       parser.input code, filename, line
 
       if print

--- a/boot/rbx-compiler/compiler/stages.rb
+++ b/boot/rbx-compiler/compiler/stages.rb
@@ -6,9 +6,9 @@ class Fancy
   class Compiler
 
     # FancyAST -> Rubinius Symbolic bytecode
-    class FancyGenerator < Rubinius::ToolSet::Runtime::Compiler::Stage
+    class FancyGenerator < Rubinius::ToolSet.current::TS::Compiler::Stage
       stage :fancy_bytecode
-      next_stage Rubinius::ToolSet::Runtime::Compiler::Encoder
+      next_stage Rubinius::ToolSet.current::TS::Compiler::Encoder
 
       attr_accessor :variable_scope
 
@@ -19,7 +19,7 @@ class Fancy
       end
 
       def run
-        @output = Rubinius::ToolSet::Runtime::Generator.new
+        @output = Rubinius::ToolSet.current::TS::Generator.new
         @input.variable_scope = @variable_scope
         @input.bytecode @output
         @output.close
@@ -32,7 +32,7 @@ class Fancy
     end
 
     # Fancy string -> AST
-    class FancyCodeParser < Rubinius::ToolSet::Runtime::Compiler::Stage
+    class FancyCodeParser < Rubinius::ToolSet.current::TS::Compiler::Stage
       stage :fancy_code
       next_stage FancyGenerator
 
@@ -64,7 +64,7 @@ class Fancy
     end
 
     # Fancy file -> AST
-    class FancyFileParser < Rubinius::ToolSet::Runtime::Compiler::Stage
+    class FancyFileParser < Rubinius::ToolSet.current::TS::Compiler::Stage
       stage :fancy_file
       next_stage FancyGenerator
 

--- a/boot/rbx-compiler/parser/parser.rb
+++ b/boot/rbx-compiler/parser/parser.rb
@@ -240,7 +240,7 @@ class Fancy
     end
 
     def nil_literal(line)
-      Rubinius::ToolSet::Runtime::AST::NilLiteral.new(line)
+      Rubinius::ToolSet.current::TS::AST::NilLiteral.new(line)
     end
 
     def partial_block(line, block_body)

--- a/lib/compiler/ast/assign.fy
+++ b/lib/compiler/ast/assign.fy
@@ -64,28 +64,28 @@ class Fancy AST {
   class Identifier {
     def bytecode: g assign: value {
       pos(g)
-      Rubinius ToolSet Runtime AST LocalVariableAssignment new(@line, name, value) bytecode(g)
+      Rubinius AST LocalVariableAssignment new(@line, name, value) bytecode(g)
     }
   }
 
   class InstanceVariable {
     def bytecode: g assign: value {
       pos(g)
-      Rubinius ToolSet Runtime AST InstanceVariableAssignment new(@line, name, value) bytecode(g)
+      Rubinius AST InstanceVariableAssignment new(@line, name, value) bytecode(g)
     }
   }
 
   class ClassVariable {
     def bytecode: g assign: value {
       pos(g)
-      Rubinius ToolSet Runtime AST ClassVariableAssignment new(@line, name, value) bytecode(g)
+      Rubinius AST ClassVariableAssignment new(@line, name, value) bytecode(g)
     }
   }
 
   class Constant {
     def bytecode: g assign: value {
       pos(g)
-      Rubinius ToolSet Runtime AST ConstantAssignment new(@line, name, value) bytecode(g)
+      Rubinius AST ConstantAssignment new(@line, name, value) bytecode(g)
     }
   }
 

--- a/lib/compiler/ast/block.fy
+++ b/lib/compiler/ast/block.fy
@@ -1,5 +1,5 @@
 class Fancy AST {
-  class BlockLiteral : Rubinius ToolSet Runtime AST Iter {
+  class BlockLiteral : Rubinius AST Iter {
     read_slot: 'body
     def initialize: @line args: @args body: @body (NilLiteral new: line) partial: @partial (false) {
       if: (@body empty?) then: {

--- a/lib/compiler/ast/class_def.fy
+++ b/lib/compiler/ast/class_def.fy
@@ -1,5 +1,5 @@
 class Fancy AST {
-  class ClassDef : Rubinius ToolSet Runtime AST Class {
+  class ClassDef : Rubinius AST Class {
     def initialize: @line name: @name parent: @parent body: @body (ExpressionList new: @line) {
       { @body = ExpressionList new: @line } unless: @body
       name = nil

--- a/lib/compiler/ast/expression_list.fy
+++ b/lib/compiler/ast/expression_list.fy
@@ -29,7 +29,7 @@ class Fancy AST {
     }
 
     def docstring {
-      if: (@expressions first kind_of?(Rubinius ToolSet Runtime AST StringLiteral)) then: {
+      if: (@expressions first kind_of?(Rubinius AST StringLiteral)) then: {
         @expressions first
       }
     }

--- a/lib/compiler/ast/identifier.fy
+++ b/lib/compiler/ast/identifier.fy
@@ -62,7 +62,7 @@ class Fancy AST {
         case "nil" -> g push_nil()
         case _ ->
           if: (g state() scope() search_local(name)) then: {
-            Rubinius ToolSet Runtime AST LocalVariableAccess new(@line, name) bytecode(g)
+            Rubinius AST LocalVariableAccess new(@line, name) bytecode(g)
           } else: {
             ms = MessageSend new: @line message: self to: (Self new: @line) args: (MessageArgs new: @line args: [])
             ms bytecode: g
@@ -75,7 +75,7 @@ class Fancy AST {
     def initialize: @line string: @string
     def bytecode: g {
       pos(g)
-      Rubinius ToolSet Runtime AST InstanceVariableAccess new(@line, name) bytecode(g)
+      Rubinius AST InstanceVariableAccess new(@line, name) bytecode(g)
     }
   }
 
@@ -83,7 +83,7 @@ class Fancy AST {
     def initialize: @line string: @string
     def bytecode: g {
       pos(g)
-      Rubinius ToolSet Runtime AST ClassVariableAccess new(@line, name) bytecode(g)
+      Rubinius AST ClassVariableAccess new(@line, name) bytecode(g)
     }
   }
 
@@ -91,7 +91,7 @@ class Fancy AST {
     def initialize: @line string: @string
     def bytecode: g {
       pos(g)
-      Rubinius ToolSet Runtime AST ConstantAccess new(@line, name) bytecode(g)
+      Rubinius AST ConstantAccess new(@line, name) bytecode(g)
     }
   }
 
@@ -114,7 +114,7 @@ class Fancy AST {
       }
       scoped = nil
       names each: |name| {
-        scoped = Rubinius ToolSet Runtime AST ScopedConstant new(@line, parent, name to_sym)
+        scoped = Rubinius AST ScopedConstant new(@line, parent, name to_sym)
         parent = scoped
       }
       scoped
@@ -132,7 +132,7 @@ class Fancy AST {
     def bytecode: g {
       pos(g)
       const_name = @string from: 2 to: -1 . to_sym # skip leading ::
-      Rubinius ToolSet Runtime AST ToplevelConstant new(@line, const_name) . bytecode(g)
+      Rubinius AST ToplevelConstant new(@line, const_name) . bytecode(g)
     }
   }
 

--- a/lib/compiler/ast/literals.fy
+++ b/lib/compiler/ast/literals.fy
@@ -1,5 +1,5 @@
 class Fancy AST {
-  class NilLiteral : Rubinius ToolSet Runtime AST NilLiteral {
+  class NilLiteral : Rubinius AST NilLiteral {
     def initialize: line {
       initialize(line)
     }
@@ -9,7 +9,7 @@ class Fancy AST {
     }
   }
 
-  class FixnumLiteral : Rubinius ToolSet Runtime AST FixnumLiteral {
+  class FixnumLiteral : Rubinius AST FixnumLiteral {
     def initialize: line value: value {
       initialize(line, value)
     }
@@ -19,7 +19,7 @@ class Fancy AST {
     }
   }
 
-  class NumberLiteral : Rubinius ToolSet Runtime AST NumberLiteral {
+  class NumberLiteral : Rubinius AST NumberLiteral {
     def initialize: line value: value {
       initialize(line, value)
     }
@@ -29,7 +29,7 @@ class Fancy AST {
     }
   }
 
-  class StringLiteral : Rubinius ToolSet Runtime AST StringLiteral {
+  class StringLiteral : Rubinius AST StringLiteral {
     def initialize: line value: value {
       initialize(line, StringHelper unescape_string(value))
     }
@@ -94,7 +94,7 @@ class Fancy AST {
     }
   }
 
-  class Self : Rubinius ToolSet Runtime AST Self {
+  class Self : Rubinius AST Self {
     def initialize: line {
       initialize(line)
     }
@@ -111,7 +111,7 @@ class Fancy AST {
     }
   }
 
-  class SymbolLiteral : Rubinius ToolSet Runtime AST SymbolLiteral {
+  class SymbolLiteral : Rubinius AST SymbolLiteral {
     read_slot: 'value
     def initialize: line value: value {
      initialize(line, value)
@@ -125,7 +125,7 @@ class Fancy AST {
     }
   }
 
-  class RegexpLiteral : Rubinius ToolSet Runtime AST RegexLiteral  {
+  class RegexpLiteral : Rubinius AST RegexLiteral  {
     def initialize: line value: value {
       initialize(line, value, 0)
     }
@@ -135,7 +135,7 @@ class Fancy AST {
     }
   }
 
-  class ArrayLiteral : Rubinius ToolSet Runtime AST ArrayLiteral {
+  class ArrayLiteral : Rubinius AST ArrayLiteral {
     read_slot: 'array
     def initialize: line array: @array {
       @array if_nil: { @array = [] }
@@ -147,7 +147,7 @@ class Fancy AST {
     }
   }
 
-  class HashLiteral : Rubinius ToolSet Runtime AST HashLiteral {
+  class HashLiteral : Rubinius AST HashLiteral {
     def initialize: line entries: @key_values {
       @key_values if_nil: { @key_values = [] }
       initialize(line, @key_values)

--- a/lib/compiler/ast/method_def.fy
+++ b/lib/compiler/ast/method_def.fy
@@ -1,5 +1,5 @@
 class Fancy AST {
-  class MethodDef : Rubinius ToolSet Runtime AST Define {
+  class MethodDef : Rubinius AST Define {
     def initialize: @line name: @name args: @arguments (MethodArgs new: @line) body: @body (ExpressionList new: @line) access: @access ('public) {
       { @body = ExpressionList new: @line } unless: @body
       @name = @name method_name: nil
@@ -15,7 +15,7 @@ class Fancy AST {
       @arguments required() reverse() each: |name| {
         if: (name to_s =~ /^@/) then: {
           ident = Identifier from: (name to_s) line: @line
-          value = Rubinius ToolSet Runtime AST LocalVariableAccess new(@line, name)
+          value = Rubinius AST LocalVariableAccess new(@line, name)
           asign = Assignment new: @line var: ident value: value
           @body unshift_expression: asign
         }
@@ -81,7 +81,7 @@ class Fancy AST {
     }
   }
 
-  class MethodArgs : Rubinius ToolSet Runtime AST FormalArguments {
+  class MethodArgs : Rubinius AST FormalArguments {
     def initialize: @line args: @array ([]) {
       initialize(@line, @array map: @{ to_sym }, nil, nil)
     }

--- a/lib/compiler/ast/node.fy
+++ b/lib/compiler/ast/node.fy
@@ -1,5 +1,5 @@
 class Fancy AST {
-  class Node : Rubinius ToolSet Runtime AST Node {
+  class Node : Rubinius AST Node {
     define_method('bytecode) |g| {
       bytecode: g
     }

--- a/lib/compiler/ast/script.fy
+++ b/lib/compiler/ast/script.fy
@@ -23,7 +23,7 @@ class Fancy AST {
         push_script
 
         # docs, code = body.expressions.partition do |s|
-        #   s.kind_of?(Rubinius::ToolSet::Runtime::AST::StringLiteral)
+        #   s.kind_of?(Rubinius::ToolSet.current::TS::AST::StringLiteral)
         # end
 
         # if code.empty?

--- a/lib/compiler/ast/singleton_method_def.fy
+++ b/lib/compiler/ast/singleton_method_def.fy
@@ -1,5 +1,5 @@
 class Fancy AST {
-  class SingletonMethodDef : Rubinius ToolSet Runtime AST DefineSingleton {
+  class SingletonMethodDef : Rubinius AST DefineSingleton {
     def initialize: @line name: @name args: @arguments body: @body access: @access owner: @receiver {
       name = @name method_name: @receiver
       @body = SingletonMethodDefScope new: @line name: name args: @arguments body: @body
@@ -11,7 +11,7 @@ class Fancy AST {
     }
   }
 
-  class SingletonMethodDefScope : Rubinius ToolSet Runtime AST DefineSingletonScope {
+  class SingletonMethodDefScope : Rubinius AST DefineSingletonScope {
     def initialize: @line name: @name args: @arguments body: @body {
       { @body = ExpressionList new: @line } unless: @body
       if: (@body empty?) then: {
@@ -26,7 +26,7 @@ class Fancy AST {
     def bytecode: g receiver: receiver {
       pos(g)
       docstring = @body docstring
-      sup = Rubinius ToolSet Runtime AST DefineSingletonScope instance_method('bytecode)
+      sup = Rubinius AST DefineSingletonScope instance_method('bytecode)
       sup bind(self) call(g, receiver)
       MethodDef set: g docstring: docstring line: @line argnames: $ @arguments names()
     }

--- a/lib/compiler/ast/try_catch.fy
+++ b/lib/compiler/ast/try_catch.fy
@@ -28,7 +28,7 @@ class Fancy AST {
       finally_ = g new_label()
       done = g new_label()
 
-      g setup_unwind(handler, Rubinius ToolSet Runtime AST EnsureType)
+      g setup_unwind(handler, Rubinius AST EnsureType)
 
       # make a break available to use
       current_break = g break()

--- a/lib/compiler/compiler.fy
+++ b/lib/compiler/compiler.fy
@@ -1,5 +1,5 @@
 class Fancy {
-  class Compiler : Rubinius ToolSet Runtime Compiler {
+  class Compiler : Rubinius Compiler {
     read_write_slots: [ 'parser, 'generator, 'packager, 'writer ]
 
     def self compiled_name: file {
@@ -28,7 +28,7 @@ class Fancy {
     def self compile_code: code vars: scope file: file line: line print: print (false) {
       compiler = from: 'fancy_code to: 'compiled_method
       parser = compiler parser
-      parser root: Rubinius ToolSet Runtime AST EvalExpression
+      parser root: Rubinius AST EvalExpression
       parser input: code file: file line: line
       if: print then: {
         parser print: true
@@ -48,7 +48,7 @@ class Fancy {
     def self compile_file: file to: output (nil) line: line (1) print: print (false) {
       compiler = from: 'fancy_file to: 'compiled_file
       parser = compiler parser
-      parser root: Rubinius ToolSet Runtime AST Script
+      parser root: Rubinius AST Script
       parser input: file line: line
       if: print then: {
         parser print: true

--- a/lib/compiler/stages.fy
+++ b/lib/compiler/stages.fy
@@ -25,7 +25,7 @@ class Fancy Compiler Stages {
     }
 
     def run {
-      @output = Rubinius ToolSet Runtime Generator new()
+      @output = Rubinius Generator new()
       @input variable_scope=(@variable_scope)
       @input bytecode(@output)
       @output close()

--- a/lib/compiler/stages.fy
+++ b/lib/compiler/stages.fy
@@ -1,7 +1,7 @@
 class Fancy Compiler Stages {
-  class Stage : Rubinius ToolSet Runtime Compiler Stage {
+  class Stage : Rubinius Compiler Stage {
     define_method('initialize) |compiler last| {
-      sup = Rubinius ToolSet Runtime Compiler Stage instance_method('initialize)
+      sup = Rubinius Compiler Stage instance_method('initialize)
       sup bind(self) call(compiler, last)
       initialize: compiler last: last
     }
@@ -16,7 +16,7 @@ class Fancy Compiler Stages {
   }
 
   class FancyGenerator : Stage {
-    stage: 'fancy_bytecode next: Rubinius ToolSet Runtime Compiler Encoder
+    stage: 'fancy_bytecode next: Rubinius Compiler Encoder
     read_write_slot: 'variable_scope
 
     def initialize: compiler last: last {


### PR DESCRIPTION
Follow-up from #72 because @bakkdoor is too fast. This switches back to using the `Rubinius AST`, `Rubinius Compiler`, etc. shortcuts in the Fancy compiler. Also using the idiomatic `Rubinius::ToolSet.current::TS` toolset access method that Rubinius uses internally.
