### PR TITLE
Improve constant performance

### DIFF
--- a/boot/fancy_ext.rb
+++ b/boot/fancy_ext.rb
@@ -16,6 +16,7 @@ require base + "console"
 require base + "delegator"
 require base + "symbol"
 require base + "array"
+require base + "rubinius"
 
 unless Rubinius::VERSION =~ /^1\./
   begin

--- a/boot/fancy_ext/module.rb
+++ b/boot/fancy_ext/module.rb
@@ -77,5 +77,18 @@ class Module
     return self
   end
 
+  # Fast constant setter. @name *must* be Symbol; @value probably shouldn't be
+  # a Module.
+  def const_set_fast(name, value)
+    # if Rubinius::Type.object_kind_of?(value, Module))
+    #   Rubinius::Type.set_module_name(value, name, self)
+    # end
+
+    @constant_table.store(name, value, :public)
+    Rubinius.inc_global_serial()
+
+    return value
+  end
+
   public :public, :private, :protected, :include, :extend
 end

--- a/boot/fancy_ext/rubinius.rb
+++ b/boot/fancy_ext/rubinius.rb
@@ -1,0 +1,7 @@
+module Rubinius
+  class ConstantScope
+    def const_set_fast(name, value)
+      @module.const_set_fast name, value
+    end
+  end
+end

--- a/lib/compiler/ast/assign.fy
+++ b/lib/compiler/ast/assign.fy
@@ -85,7 +85,11 @@ class Fancy AST {
   class Constant {
     def bytecode: g assign: value {
       pos(g)
-      Rubinius AST ConstantAssignment new(@line, name, value) bytecode(g)
+      # Rubinius AST ConstantAssignment new(@line, name, value) bytecode(g)
+      g push_scope()
+      g push_literal(name)
+      value bytecode: g
+      g send('const_set_fast, 2)
     }
   }
 

--- a/lib/compiler/ast/assign.fy
+++ b/lib/compiler/ast/assign.fy
@@ -85,10 +85,12 @@ class Fancy AST {
   class Constant {
     def bytecode: g assign: value {
       pos(g)
-      # Rubinius AST ConstantAssignment new(@line, name, value) bytecode(g)
-      g push_scope()
-      g push_literal(name)
+      #Rubinius AST ConstantAssignment new(@line, name, value) bytecode(g)
+      # Must eventually be: scope, literal, value
       value bytecode: g
+      g push_literal(name)
+      g push_scope()
+      g rotate(3)
       g send('const_set_fast, 2)
     }
   }

--- a/lib/compiler/ast/assign.fy
+++ b/lib/compiler/ast/assign.fy
@@ -83,14 +83,14 @@ class Fancy AST {
   }
 
   class Constant {
+    # NOTE: Based off of Rubinius::AST::ConstantAssignment
     def bytecode: g assign: value {
       pos(g)
-      #Rubinius AST ConstantAssignment new(@line, name, value) bytecode(g)
-      # Must eventually be: scope, literal, value
-      value bytecode: g
-      g push_literal(name)
-      g push_scope()
-      g rotate(3)
+      value bytecode: g    # S: value
+      g push_literal(name) # S: value, name
+      g push_scope()       # S: value, name, scope
+      g rotate(3) # Flip, so S: scope, name, value
+      # Invoke Fancy-specific Module#const_set_fast (boot/fancy_ext/module.rb).
       g send('const_set_fast, 2)
     }
   }

--- a/lib/compiler/ast/identifier.fy
+++ b/lib/compiler/ast/identifier.fy
@@ -91,7 +91,7 @@ class Fancy AST {
     def initialize: @line string: @string
     def bytecode: g {
       pos(g)
-      # Rubinius AST ConstantAccess new(@line, name) bytecode(g)
+      # Use quick constant lookup (top-level handled in TopLevelConstant).
       g push_const(name)
     }
   }

--- a/lib/compiler/ast/identifier.fy
+++ b/lib/compiler/ast/identifier.fy
@@ -91,7 +91,8 @@ class Fancy AST {
     def initialize: @line string: @string
     def bytecode: g {
       pos(g)
-      Rubinius AST ConstantAccess new(@line, name) bytecode(g)
+      # Rubinius AST ConstantAccess new(@line, name) bytecode(g)
+      g push_const(name)
     }
   }
 

--- a/tests/module.fy
+++ b/tests/module.fy
@@ -5,6 +5,7 @@ class TestModuleConstant {
     Constant = true
   }
 }
+TestModuleConstantMultiA, TestModuleConstantMultiB = 1, 2
 
 FancySpec describe: Module with: {
   it: "preserves method documentation when dynamically overwriting" \
@@ -35,6 +36,10 @@ FancySpec describe: Module with: {
     TestModuleTopLevelConstant is_not: 'other
     TestModuleTopLevelConstant = 'other
     TestModuleTopLevelConstant is: 'other
+  }
+  it: "multiple-assigns constants" when: {
+    TestModuleConstantMultiA is: 1
+    TestModuleConstantMultiB is: 2
   }
 
 }#/Module

--- a/tests/module.fy
+++ b/tests/module.fy
@@ -1,3 +1,4 @@
+# Used in top-level module constant and nested constast tests.
 TestModuleTopLevelConstant = true
 class TestModuleConstant {
   Constant = true
@@ -5,6 +6,7 @@ class TestModuleConstant {
     Constant = true
   }
 }
+# Used in multiple-assigns constant test.
 TestModuleConstantMultiA, TestModuleConstantMultiB = 1, 2
 
 FancySpec describe: Module with: {
@@ -27,7 +29,7 @@ FancySpec describe: Module with: {
     Bar instance_method: 'foo . documentation to_s is: "bar"
   }#/preserve method documentation
   
-  it: "gets constants" when: {
+  it: "get top-level constants" when: {
     TestModuleTopLevelConstant is_not: nil
     TestModuleConstant Constant is: true
     TestModuleConstant Nested Constant is: true
@@ -37,9 +39,20 @@ FancySpec describe: Module with: {
     TestModuleTopLevelConstant = 'other
     TestModuleTopLevelConstant is: 'other
   }
-  it: "multiple-assigns constants" when: {
+  it: "multiple-assigns top-level constants" when: {
     TestModuleConstantMultiA is: 1
     TestModuleConstantMultiB is: 2
+  }
+  it: "gets and sets local constants" when: {
+    A = true
+    A is: true
+    A = false
+    A is: false
+  }
+  it: "multiple-assigns local constants" when: {
+    B, C = 1, 2
+    B is: 1
+    C is: 2
   }
 
 }#/Module

--- a/tests/module.fy
+++ b/tests/module.fy
@@ -1,3 +1,11 @@
+TestModuleTopLevelConstant = true
+class TestModuleConstant {
+  Constant = true
+  class Nested {
+    Constant = true
+  }
+}
+
 FancySpec describe: Module with: {
   it: "preserves method documentation when dynamically overwriting" \
   with: 'overwrite_method:with_dynamic: when: {
@@ -17,5 +25,16 @@ FancySpec describe: Module with: {
     # Make sure it's preserved
     Bar instance_method: 'foo . documentation to_s is: "bar"
   }#/preserve method documentation
+  
+  it: "gets constants" when: {
+    TestModuleTopLevelConstant is_not: nil
+    TestModuleConstant Constant is: true
+    TestModuleConstant Nested Constant is: true
+  }
+  it: "sets top-level constants" when: {
+    TestModuleTopLevelConstant is_not: 'other
+    TestModuleTopLevelConstant = 'other
+    TestModuleTopLevelConstant is: 'other
+  }
 
 }#/Module


### PR DESCRIPTION
Looks like the system was doing a lot more work than necessary when assigning constants (Rubinius' built-in `const_set` and constant AST classes are a bit bloated for Fancy); this trims everything down and fixes multiple-assignment with constants (which seems to have been broken).
